### PR TITLE
refactor(waku): use dns discovery to conntect waku node

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2104,9 +2104,9 @@ checksum = "fcb4d3d38eab6c5239a362fa8bae48c03baf980a6e7079f063942d563ef3533e"
 
 [[package]]
 name = "libloading"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
+checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
  "windows-targets 0.52.6",
@@ -2443,6 +2443,7 @@ dependencies = [
  "chrono",
  "clap",
  "futures",
+ "libloading",
  "nostr-sdk",
  "rand",
  "reqwest",
@@ -3015,7 +3016,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.7",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ base64 = "0.22.1"
 chrono = "0.4.38"
 clap = { version = "4.5.21", features = ["derive"] }
 futures = "0.3.31"
+libloading = "0.8.6"
 nostr-sdk = { version = "0.37.0", features = ["all-nips"] }
 rand = "0.8.5"
 reqwest = { version = "0.12.9", features = ["default", "json"] }

--- a/src/common/config.rs
+++ b/src/common/config.rs
@@ -29,9 +29,11 @@ pub struct WakuConfig {
     pub pubsub_topic: String,
     pub content_topic: String,
     pub node_addr: String,
-    pub cluster_id: String,
-    pub shared: String,
-    pub waku_bin: String,
+    pub cluster_id: usize,
+    pub shared: Vec<usize>,
+    pub waku_dylib: String,
+    pub dns_url: String,
+    pub key: Option<String>,
 }
 
 #[derive(Clone, Debug, Deserialize)]

--- a/src/waku/pubsub.rs
+++ b/src/waku/pubsub.rs
@@ -6,21 +6,37 @@
 use crate::common::config::WakuConfig;
 use aes_gcm::{Aes256Gcm, KeyInit};
 use chrono::Utc;
+use libloading::{Library, Symbol};
 use nostr_sdk::prelude::Event as NostrEvent;
 use rand::thread_rng;
 use secp256k1::SecretKey;
+use std::ffi::c_void;
 use std::io::{self, BufRead};
 use std::net::IpAddr;
 use std::process::{Command, Stdio};
 use std::str::FromStr;
+use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 use std::{collections::HashSet, str::from_utf8};
-use tokio::sync::mpsc::{self};
-use waku_bindings::{
-    waku_default_pubsub_topic, waku_new, waku_set_event_callback, ContentFilter, Encoding, Event,
-    Key, MessageId, Multiaddr, PagingOptions, ProtocolId, Running, StoreQuery, WakuContentTopic,
-    WakuLogLevel, WakuMessage, WakuNodeConfig, WakuNodeHandle, WakuPubSubTopic,
-};
+use tokio::sync::mpsc;
+
+pub const dns_url: &str = "enrtree://AMOJVZX4V6EXP7NTJPMAYJYST2QP6AJXYW76IU6VGJS7UVSNDYZG4@boot.prod.status.nodes.status.im";
+
+pub struct WakuNodeHandle {
+    pub ctx: WakuNodeContext,
+}
+
+pub struct WakuNodeContext {
+    pub obj_ptr: *mut c_void,
+}
+
+unsafe impl Sync for WakuNodeHandle {}
+unsafe impl Send for WakuNodeHandle {}
+
+#[derive(Debug)]
+pub struct Response {
+    pub payload: String,
+}
 
 /// Struct representing a Waku client.
 ///
@@ -29,11 +45,9 @@ use waku_bindings::{
 /// and pubsub.
 pub struct WakuClient {
     config: WakuConfig,
-    node_handle: WakuNodeHandle<Running>,
-    ec_privkey: SecretKey,
-    aes_key: Key<Aes256Gcm>,
-    content_topic: WakuContentTopic,
-    pubsub_topic: WakuPubSubTopic,
+    node_handle: WakuNodeHandle,
+    content_topic: String,
+    pubsub_topic: String,
 }
 
 impl WakuClient {
@@ -42,191 +56,81 @@ impl WakuClient {
     /// This struct contains configuration for the client, a handle to the running Waku node, an elliptic
     /// curve private key for encryption, an AES key for additional encryption, and topics for content
     /// and pubsub.
-    pub async fn new(config: WakuConfig) -> Result<WakuClient, String> {
-        let node_url = config.node_url.clone();
-        let node_addr = config.node_addr.clone();
-        let node_config = WakuNodeConfig {
-            host: IpAddr::from_str(node_url.as_str()).ok(),
-            log_level: Some(WakuLogLevel::Error),
-            ..Default::default()
-        };
+    pub fn new(config: WakuConfig) -> Result<WakuClient, String> {
+        println!("{:?}", config);
+        unsafe {
+            let lib = Library::new(config.waku_dylib.clone()).unwrap();
+            let waku_new: Symbol<
+                unsafe fn(
+                    usize,
+                    Vec<usize>,
+                    &str,
+                    Option<SecretKey>,
+                    &str,
+                ) -> Result<WakuNodeHandle, String>,
+            > = lib.get(b"waku_new_wrapper").unwrap();
 
-        let node = waku_new(Some(node_config))?;
-        let node = node.start()?;
-        tracing::info!("Node peer id: {}", node.peer_id()?);
+            let node = waku_new(
+                config.cluster_id,
+                config.shared.clone(),
+                config.dns_url.as_str(),
+                config
+                    .key
+                    .clone()
+                    .map(|k| SecretKey::from_str(k.as_str()).unwrap()),
+                config.pubsub_topic.as_str(),
+            )
+            .unwrap();
 
-        let address: Multiaddr = node_addr.parse().unwrap();
-        let peer_id = node.add_peer(&address, ProtocolId::Relay)?;
-        node.connect_peer_with_id(&peer_id, None)?;
-
-        let content_topic: WakuContentTopic = config.content_topic.parse().unwrap();
-        let content_filter = ContentFilter::new(
-            Some(config.pubsub_topic.parse().unwrap()),
-            vec![content_topic.clone()],
-        );
-        node.relay_subscribe(&content_filter)?;
-
-        let sk = SecretKey::new(&mut thread_rng());
-        let ssk = Aes256Gcm::generate_key(&mut thread_rng());
-
-	let pubsub = config.pubsub_topic.clone();
-
-        Ok(WakuClient {
-            config,
-            ec_privkey: sk,
-            aes_key: ssk,
-            node_handle: node,
-            content_topic,
-            pubsub_topic: pubsub.parse().unwrap(),
-        })
-    }
-
-    fn try_publish_relay_messages(&self, msg: &WakuMessage) -> Result<HashSet<MessageId>, String> {
-        Ok(HashSet::from([self
-            .node_handle
-            .relay_publish_message(msg, None, None)?]))
-    }
-
-    fn try_publish_lightpush_messages(
-        self,
-        msg: &WakuMessage,
-    ) -> Result<HashSet<MessageId>, String> {
-        let peer_id = self
-            .node_handle
-            .peers()
-            .unwrap()
-            .iter()
-            .map(|peer| peer.peer_id())
-            .find(|id| id.as_str() != self.node_handle.peer_id().unwrap().as_str())
-            .unwrap()
-            .clone();
-
-        Ok(HashSet::from([self
-            .node_handle
-            .lightpush_publish(msg, None, peer_id, None)?]))
+            Ok(WakuClient {
+                config: config.clone(),
+                node_handle: node,
+                content_topic: config.content_topic.clone(),
+                pubsub_topic: config.pubsub_topic.clone(),
+            })
+        }
     }
 
     /// Sends a message through the Waku relay.
     ///
     /// This method creates a new Waku message, publishes it through the relay, and returns the
     /// message IDs of the successfully sent messages.
-    pub async fn send_message(&self, content: String) -> Result<HashSet<MessageId>, String> {
-        let message = WakuMessage::new(
-            content,
-            self.content_topic.clone(),
-            1,
-            SystemTime::now()
-                .duration_since(SystemTime::UNIX_EPOCH)
-                .unwrap()
-                .as_millis()
-                .try_into()
-                .unwrap(),
-            Vec::new(),
-            false,
-        );
+    pub fn send_message(&self, content: String) -> Result<(), String> {
+        unsafe {
+            let lib = Library::new(self.config.waku_dylib.clone()).unwrap();
+            let waku_send: Symbol<
+                unsafe fn(&WakuNodeHandle, &str, &str, String) -> Result<(), String>,
+            > = lib.get(b"waku_send").unwrap();
 
-        let ids = self
-            .try_publish_relay_messages(&message)
-            .expect("send relay messages");
-
-        Ok(ids)
-    }
-
-    pub async fn listening_message_gowrapper(&self, tx: mpsc::Sender<String>) {
-        let mut child = Command::new(self.config.waku_bin.clone())
-            .arg("verify")
-            .arg("--shard")
-            .arg(self.config.shared.clone())
-            .arg("--maddr")
-            .arg(self.config.node_addr.clone())
-            .stdout(Stdio::piped())
-            .spawn()
-            .unwrap();
-
-        let stdout = child.stdout.take().expect("Failed to capture stdout");
-
-        let reader = io::BufReader::new(stdout);
-
-        for line in reader.lines() {
-            match line {
-                Ok(line) => {
-                    println!("Received from Go: {}", line);
-                    tx.send(line).await;
-                }
-                Err(e) => eprintln!("Error reading line: {}", e),
-            }
+            waku_send(
+                &self.node_handle,
+                &self.pubsub_topic,
+                &self.content_topic,
+                content,
+            );
         }
 
-        let status = child.wait().unwrap();
-        println!("Go server exited with status: {}", status);
+        Ok(())
     }
 
-    pub async fn listening_message(&self, tx: mpsc::Sender<NostrEvent>) {
-        //let history = self.retrieve_history();
+    pub fn listening_message(&self, tx: mpsc::Sender<Response>) {
+        unsafe {
+            let lib = Library::new(self.config.waku_dylib.clone()).unwrap();
+            let waku_listen: Symbol<
+                unsafe fn(
+                    &WakuNodeHandle,
+                    &str,
+                    &str,
+                    mpsc::Sender<Response>,
+                ) -> Result<(), String>,
+            > = lib.get(b"waku_listen").unwrap();
 
-	let content_topic_cl = self.content_topic.clone();
-        waku_set_event_callback(move |signal| {
-            if let Event::WakuMessage(message) = signal.event() {
-                let id = message.message_id();
-                tracing::info!("got waku event: {:?}", id);
-                let message = message.waku_message();
-
-                if message.content_topic() != &content_topic_cl {
-                    return;
-                }
-                let payload = message.payload().to_vec();
-                let msg = from_utf8(&payload).expect("should be valid message");
-                match serde_json::from_str::<NostrEvent>(msg) {
-                    Ok(event) => {
-                        futures::executor::block_on(tx.send(event))
-                            .expect("send response to the receiver");
-                    }
-                    Err(e) => {
-                        tracing::error!("{:?}", e);
-                    }
-                }
-            }
-        });
-    }
-
-    fn retrieve_history(&self) -> waku_bindings::Result<Vec<NostrEvent>> {
-        let self_id = self.node_handle.peer_id().unwrap();
-        let peer = self
-            .node_handle
-            .peers()?
-            .iter()
-            .find(|&peer| peer.peer_id() != &self_id)
-            .cloned()
-            .unwrap();
-
-        let result = self.node_handle.store_query(
-            &StoreQuery {
-                pubsub_topic: None,
-                content_topics: vec![self.content_topic.clone()],
-                start_time: Some(
-                    (Duration::from_secs(Utc::now().timestamp() as u64)
-                        - Duration::from_secs(60 * 60 * 24))
-                    .as_nanos() as usize,
-                ),
-                end_time: None,
-                paging_options: Some(PagingOptions {
-                    page_size: 25,
-                    cursor: None,
-                    forward: true,
-                }),
-            },
-            peer.peer_id(),
-            Some(Duration::from_secs(10)),
-        )?;
-
-        Ok(result
-            .messages()
-            .iter()
-            .map(|waku_message| {
-                let msg = from_utf8(waku_message.payload()).expect("should be valid message");
-                serde_json::from_str::<NostrEvent>(msg)
-                    .expect("Toy chat messages should be decodeable")
-            })
-            .collect())
+            waku_listen(
+                &self.node_handle,
+                self.pubsub_topic.as_str(),
+                self.content_topic.as_str(),
+                tx,
+            );
+        }
     }
 }

--- a/templates/config.yaml
+++ b/templates/config.yaml
@@ -15,9 +15,16 @@ nostr:
 waku:
   node_url: "0.0.0.0"
   send_api: "http://127.0.0.1:8645/relay/v1/auto/messages"
-  pubsub_topic: "/waku/2/rs/1/6"
-  content_topic: "/basic/1/test/proto"
+  pubsub_topic: "/waku/2/rs/16/32"
+  content_topic: "/waku/9/test/proto"
   node_addr: "/ip4/213.136.84.124/tcp/30304/p2p/16Uiu2HAm54nognWMn36kkMzPdHPcNDteeRC2cfWCHSkkJKyG4oQd"
-  cluster_id: "1"
-  shared: "6"
-  waku_bin: "./basic2"
+  cluster_id: 16
+  shared:
+    - 1
+    - 32
+    - 64
+    - 128
+    - 256
+  waku_dylib: "./libs/libwaku_bindings.so"
+  dns_url: "enrtree://AMOJVZX4V6EXP7NTJPMAYJYST2QP6AJXYW76IU6VGJS7UVSNDYZG4@boot.prod.status.nodes.status.im"
+  key: "2fc0515879e52b7b73297cfd6ab3abf7c344ef84b7a90ff6f4cc19e05a198027"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added new fields `dns_url` and `key` to the configuration.
	- Introduced dynamic library loading for Waku node management.
	- Enhanced message handling with new structures and simplified methods.

- **Bug Fixes**
	- Improved error handling in message sending and listening methods.

- **Documentation**
	- Updated configuration file with new topics and structure.

- **Chores**
	- Cleaned up import statements and refactored code for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->